### PR TITLE
Get apods by date

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev
 - [x] Simple Feature flag system using OpenFeature and `InMemoryProvider`
 - [x] Display today's APOD
 - [x] Display information from today's APOD using a simple web-scraper
-- [ ] Select other days, go back and forward a day
+- [x] Select other days, go back and forward a day
 - [ ] Add functionality for storing/caching APOD images and metadata
 
 ## Stretch-Goals

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -16,6 +16,9 @@ const apodScraper = new ApodScraper({ copyrightRestrict: false });
 
 app.use(cors())
 
+// For parsing application/json
+app.use(express.json());
+
 // Set up middleware
 app.use((_, res, next) => {
   res.setHeader("content-type", "text/plain");
@@ -49,8 +52,15 @@ app.get('/api/feature-flag-table', async (req, res) => {
   res.send(body);
 })
 
-app.get("/api/apod/today", async (req, res) => {
+app.get("/api/apod/today", async (_, res) => {
   res.send(await apodScraper.today());
+})
+
+app.post("/api/apod", async (req, res) => {
+  const date = new Date(req.body.date);
+  const apod = await apodScraper.fromDay(date)
+    .catch((e) => console.error(e));
+  res.send(apod);
 })
 
 app.listen(port, () => {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -12,7 +12,7 @@ const routes = express.Router();
 const port = 3070;
 
 const featureFlagManager = new FeatureFlagAPIManager();
-const apodScraper = new ApodScraper(false);
+const apodScraper = new ApodScraper({ copyrightRestrict: false });
 
 app.use(cors())
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -59,7 +59,12 @@ app.get("/api/apod/today", async (_, res) => {
 app.post("/api/apod", async (req, res) => {
   const date = new Date(req.body.date);
   const apod = await apodScraper.fromDay(date)
-    .catch((e) => console.error(e));
+    .catch(async (e) => {
+      console.error(e);
+      // Send today's apod as fallback (in most cases this is when trying to
+      // access the future)
+      res.send(await apodScraper.today());
+    });
   res.send(apod);
 })
 

--- a/backend/src/utils/apodScraper.ts
+++ b/backend/src/utils/apodScraper.ts
@@ -198,7 +198,6 @@ export class ApodScraper {
     const dd = String(date.getDate()).padStart(2, '0');
 
     const url = `${APOD_URL}/apod/ap${yy}${mm}${dd}.html`;
-    console.log(url);
     return await this.getApodFromUrl(url)
   }
 }

--- a/backend/src/utils/apodScraper.ts
+++ b/backend/src/utils/apodScraper.ts
@@ -193,10 +193,12 @@ export class ApodScraper {
 
   public async fromDay(date: Date): Promise<Apod> {
     const yy = String(date.getFullYear() % 100).padStart(2, '0');
-    const mm = String(date.getMonth()).padStart(2, '0');
-    const dd = String(date.getDay()).padStart(2, '0');
+    // Date returns date index, hence the "+ 1"
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
 
     const url = `${APOD_URL}/apod/ap${yy}${mm}${dd}.html`;
+    console.log(url);
     return await this.getApodFromUrl(url)
   }
 }

--- a/backend/src/utils/apodScraper.ts
+++ b/backend/src/utils/apodScraper.ts
@@ -153,6 +153,9 @@ export class ApodScraper {
   async getApodWebDataExtractor(url: string) {
     // Go to apod and get html
     const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Couldn't get apod web data from URL "${url}". Status: ${res.status}`)
+    }
     const html = await res.text();
 
     // Parse using cheerio
@@ -186,5 +189,14 @@ export class ApodScraper {
 
   public async today(): Promise<Apod> {
     return await this.getApodFromUrl(APOD_URL);
+  }
+
+  public async fromDay(date: Date): Promise<Apod> {
+    const yy = String(date.getFullYear() % 100).padStart(2, '0');
+    const mm = String(date.getMonth()).padStart(2, '0');
+    const dd = String(date.getDay()).padStart(2, '0');
+
+    const url = `${APOD_URL}/apod/ap${yy}${mm}${dd}.html`;
+    return await this.getApodFromUrl(url)
   }
 }

--- a/backend/src/utils/apodScraper.ts
+++ b/backend/src/utils/apodScraper.ts
@@ -134,14 +134,20 @@ class ApodScraperError extends Error {
   }
 }
 
-
-export class ApodScraper {
+interface ApodScraperConfig {
   // Will refrain from sending the image link when image is copyrighted.
   // This is mostly out of abundance of caution, as I am not a legal expert.
   copyrightRestrict: boolean;
+}
 
-  constructor(allowCopyright: boolean) {
-    this.copyrightRestrict = allowCopyright;
+export class ApodScraper {
+  config: ApodScraperConfig = {
+    copyrightRestrict: true
+  };
+
+  constructor(config?: Partial<ApodScraperConfig>) {
+    if (!config) return;
+    this.config = { ...this.config, ...config };
   }
 
   async getApodWebDataExtractor(url: string) {
@@ -171,7 +177,7 @@ export class ApodScraper {
       }
     });
 
-    return new ApodWebDataExtractor(data, this.copyrightRestrict);
+    return new ApodWebDataExtractor(data, this.config.copyrightRestrict);
   }
 
   async getApodFromUrl(url: string) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import { useState } from 'react';
 import './App.css';
-import FlagInfo from '@/components/FlagInfo';
-import UserInfo from '@/components/UserInfo';
 import ApodContainer from '@/components/ApodContainer';
+import DateDisplay from '@/components/DateDisplay';
 
 function App() {
+  const [date, setDate] = useState(new Date());
+
   return (
     <div className="App">
       <header className="App-header">
-        <UserInfo />
-        <FlagInfo />
+        <DateDisplay date={date} setDate={setDate} />
         <ApodContainer />
       </header>
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ function App() {
     <div className="App">
       <header className="App-header">
         <DateDisplay date={date} setDate={setDate} />
-        <ApodContainer />
+        <ApodContainer date={date} />
       </header>
     </div>
   );

--- a/frontend/src/components/ApodContainer.tsx
+++ b/frontend/src/components/ApodContainer.tsx
@@ -8,16 +8,26 @@ type ApodDisplayState = "loading" | Apod;
 
 const APOD_URL = "https://apod.nasa.gov"
 
-export default function ApodContainer() {
+// Dependency list tells the container what variables to refresh on
+export default function ApodContainer({ date }: { date: Date }) {
   const [displayState, setDisplayState] = useState<ApodDisplayState>("loading");
 
   useEffect(() => {
-    fetch(`${serverUrl}/api/apod/today`)
+    setDisplayState("loading");
+    const today = date.getDate() === new Date().getDate();
+    const endpoint = today ? "apod/today" : "apod"
+    fetch(`${serverUrl}/api/${endpoint}`, {
+      method: today ? "GET" : "POST",
+      headers: today ? undefined : {
+        "Content-Type": "application/json"
+      },
+      body: today ? undefined : JSON.stringify({ date: date })
+    })
       .then(async r => await r.json())
       .then(setDisplayState);
-  }, [])
+  }, [date])
 
-  return displayState == "loading" ? (
+  return displayState === "loading" ? (
     <h1>Loading Astronomy Picture of the Day...</h1>
   ) : (
     <ApodDisplay apod={displayState} />
@@ -32,7 +42,7 @@ function ApodDisplay({ apod }: { apod: Apod }) {
   return (
     <>
       <h1>{apod.title}</h1>
-      <img src={`${APOD_URL}/${apod.imageLink}`} />
+      <img src={`${APOD_URL}/${apod.imageLink}`} alt={apod.title} />
       <p>
         Image Credit: <a href={imageCredits.link}>{imageCredits.name}</a>
       </p>

--- a/frontend/src/components/DateDisplay.tsx
+++ b/frontend/src/components/DateDisplay.tsx
@@ -3,6 +3,7 @@ export default function DateDisplay(
 ) {
   const monthName = date.toLocaleDateString("default", { month: "long" });
   const day = ordinalSuffix(date.getDate());
+  const today = isToday(date);
   return (
     <div>
       {/* This line looks terrible, but it makes sense trust.
@@ -12,10 +13,17 @@ export default function DateDisplay(
       */}
       <button onClick={() => setDate(new Date(date.setDate(date.getDate() - 1)))}> Yesterday </button>
       {`${date.getFullYear()} ${monthName} ${day}`}
-      {date.getDate() === new Date().getDate() ? " (Today)" : ""}
-      <button onClick={() => setDate(new Date(date.setDate(date.getDate() + 1)))}> Tomorrow </button>
+      {today ? " (Today)" : ""}
+      <button disabled={today} onClick={() => setDate(new Date(date.setDate(date.getDate() + 1)))}> Tomorrow </button>
     </div>
   )
+}
+
+function isToday(date: Date) {
+  const today = new Date();
+  return date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
 }
 
 function ordinalSuffix(n: number): string {

--- a/frontend/src/components/DateDisplay.tsx
+++ b/frontend/src/components/DateDisplay.tsx
@@ -12,6 +12,7 @@ export default function DateDisplay(
       */}
       <button onClick={() => setDate(new Date(date.setDate(date.getDate() - 1)))}> Yesterday </button>
       {`${date.getFullYear()} ${monthName} ${day}`}
+      {date.getDate() === new Date().getDate() ? " (Today)" : ""}
       <button onClick={() => setDate(new Date(date.setDate(date.getDate() + 1)))}> Tomorrow </button>
     </div>
   )

--- a/frontend/src/components/DateDisplay.tsx
+++ b/frontend/src/components/DateDisplay.tsx
@@ -1,0 +1,32 @@
+export default function DateDisplay(
+  { date, setDate }: { date: Date, setDate: React.Dispatch<React.SetStateAction<Date>> }
+) {
+  const monthName = date.toLocaleDateString("default", { month: "long" });
+  const day = ordinalSuffix(date.getDate());
+  return (
+    <div>
+      {/* This line looks terrible, but it makes sense trust.
+        setDate() in the Date class takes care of overflow and underflow with
+        the months, while setDate() takes care of the React state.
+        Date constructor is needed because date.setDate returns a number
+      */}
+      <button onClick={() => setDate(new Date(date.setDate(date.getDate() - 1)))}> Yesterday </button>
+      {`${date.getFullYear()} ${monthName} ${day}`}
+      <button onClick={() => setDate(new Date(date.setDate(date.getDate() + 1)))}> Tomorrow </button>
+    </div>
+  )
+}
+
+function ordinalSuffix(n: number): string {
+  if (n > 3 && n < 21) return n + "th";
+  switch (n % 10) {
+    case 1:
+      return n + "st";
+    case 2:
+      return n + "nd";
+    case 3:
+      return n + "rd";
+    default:
+      return n + "th";
+  }
+}


### PR DESCRIPTION
# Summary 

You can now select different days to get the apod from on the backend and there's a date display on the frontend that allows you to navigate to "yesterday" and "tomorrow". In hindsight, those terms don't really work very well in the past, so I'll plan on replacing them with icons.

<img width="1139" height="845" alt="image" src="https://github.com/user-attachments/assets/20e8c1e6-8baf-4daf-938f-c90f0b66eee5" />

No calendar select yet. I might want to use some external package for that. Sounds like a lot of work that has definitely been done by someone else.