### PR TITLE
Apod Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Don't track cached markdown files
+backend/cache/**

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ bower_components
 .lock-wscript
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
-build/Release
+**/build/Release
 
 # Dependency directories
 node_modules/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm run dev
 - [x] Display today's APOD
 - [x] Display information from today's APOD using a simple web-scraper
 - [x] Select other days, go back and forward a day
-- [ ] Add functionality for storing/caching APOD images and metadata
+- [x] Add functionality for storing/caching APOD images and metadata
 
 ## Stretch-Goals
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,12 +14,14 @@
         "cors": "^2.8.6",
         "cowsay": "^1.6.0",
         "express": "^5.2.1",
+        "js-yaml": "^4.1.1",
         "tsx": "^4.21.0",
         "turndown": "^7.2.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
+        "@types/js-yaml": "^4.0.9",
         "@types/turndown": "^5.0.6",
         "ts-node": "^10.9.2",
         "tsc-alias": "^1.8.16",
@@ -637,6 +639,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
@@ -772,6 +781,12 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -1868,6 +1883,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,12 +18,14 @@
     "cors": "^2.8.6",
     "cowsay": "^1.6.0",
     "express": "^5.2.1",
+    "js-yaml": "^4.1.1",
     "tsx": "^4.21.0",
     "turndown": "^7.2.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
+    "@types/js-yaml": "^4.0.9",
     "@types/turndown": "^5.0.6",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.16",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,7 @@ import cowsay from "cowsay";
 import cors from "cors";
 import { FeatureFlagAPIManager } from "@/utils/featureFlags.ts";
 import { ApodScraper } from "@/utils/apodScraper.ts";
+import { ApodCache } from "./utils/apodCache.ts";
 
 /// Declare and set up express application
 
@@ -13,6 +14,8 @@ const port = 3070;
 
 const featureFlagManager = new FeatureFlagAPIManager();
 const apodScraper = new ApodScraper({ copyrightRestrict: false });
+const apodCache = new ApodCache({ cacheDir: "./cache" });
+apodCache.initCache();
 
 app.use(cors())
 
@@ -53,19 +56,27 @@ app.get('/api/feature-flag-table', async (req, res) => {
 })
 
 app.get("/api/apod/today", async (_, res) => {
-  res.send(await apodScraper.today());
+  var apodMd;
+  const today = new Date();
+  if (apodCache.has(today)) {
+    apodMd = await apodCache.getApod(today)
+  } else {
+    const apodObj = await apodScraper.today();
+    apodMd = await apodCache.writeApod(apodObj);
+  }
+  res.send(apodMd);
 })
 
 app.post("/api/apod", async (req, res) => {
   const date = new Date(req.body.date);
-  const apod = await apodScraper.fromDay(date)
-    .catch(async (e) => {
-      console.error(e);
-      // Send today's apod as fallback (in most cases this is when trying to
-      // access the future)
-      res.send(await apodScraper.today());
-    });
-  res.send(apod);
+  var apodMd;
+  if (apodCache.has(date)) {
+    apodMd = await apodCache.getApod(date)
+  } else {
+    const apodObj = await apodScraper.fromDay(date);
+    apodMd = await apodCache.writeApod(apodObj);
+  }
+  res.send(apodMd);
 })
 
 app.listen(port, () => {

--- a/backend/src/types/apod.ts
+++ b/backend/src/types/apod.ts
@@ -5,12 +5,13 @@ export default interface Apod {
     // An image can have multiple people credited
     image: {
       name: string;
-      link: string;
+      // Credits don't always have a link
+      link: string | undefined;
     }[];
     // Text might not be credited if it wasn't from a volunteer
     // TODO: Text credits often have credentials (ex. "(NASA, GSFC)") that are
     // linked.
-    text?: {
+    text: {
       name: string;
       link: string;
     } | undefined;

--- a/backend/src/types/apod.ts
+++ b/backend/src/types/apod.ts
@@ -2,14 +2,18 @@ export default interface Apod {
   date: Date;
   title: string;
   credits: {
+    // An image can have multiple people credited
     image: {
       name: string;
       link: string;
-    };
-    text: {
+    }[];
+    // Text might not be credited if it wasn't from a volunteer
+    // TODO: Text credits often have credentials (ex. "(NASA, GSFC)") that are
+    // linked.
+    text?: {
       name: string;
       link: string;
-    };
+    } | undefined;
   };
   copyright: boolean;
   description: string;

--- a/backend/src/utils/apodCache.ts
+++ b/backend/src/utils/apodCache.ts
@@ -1,0 +1,56 @@
+// apodCache handles the filesystem storage of APOD metadata
+import type Apod from "@/types/apod.ts";
+import * as fs from "fs/promises";
+import * as fsSync from "fs";
+import YAML from "js-yaml";
+import { abbreviate } from "./dateUtils.ts";
+
+// Make description optional so we can delete it and put it in the markdown body
+type ApodFrontmatter = Omit<Apod, "description"> & Partial<Pick<Apod, "description">>
+
+interface ApodCacheConfig {
+  cacheDir: string
+}
+
+export class ApodCache {
+  config: ApodCacheConfig = {
+    cacheDir: "./cache"
+  }
+
+  constructor(config?: Partial<ApodCacheConfig>) {
+    this.config = { ...this.config, ...config };
+  }
+
+  getPath(date: Date): string {
+    return `${this.config.cacheDir}/${abbreviate(date)}.md`;
+  }
+
+  public async initCache() {
+    if (fsSync.existsSync(this.config.cacheDir)) return;
+    await fs.mkdir(this.config.cacheDir, { mode: 0o755 });
+  }
+
+  public has(date: Date) {
+    const path = this.getPath(date);
+    return fsSync.existsSync(path);
+  }
+
+  public async writeApod(apod: Apod): Promise<string> {
+    const description = apod.description;
+    const frontmatter: ApodFrontmatter = apod;
+    delete frontmatter.description;
+    const yaml = YAML.dump(frontmatter);
+    const content = `---\n${yaml}---\n${description}`;
+    const path = this.getPath(apod.date);
+
+    await fs.writeFile(path, content);
+
+    return content;
+  }
+
+  public async getApod(date: Date): Promise<string> {
+    const path = this.getPath(date);
+
+    return await fs.readFile(path, "utf-8");
+  }
+}

--- a/backend/src/utils/apodScraper.ts
+++ b/backend/src/utils/apodScraper.ts
@@ -85,10 +85,10 @@ class ApodWebDataExtractor {
     const imgCreditName = data.creditText[0]!;
     const textCreditName = data.creditText[1]!;
     const credits = {
-      image: {
+      image: [{
         name: imgCreditName,
         link: imgCreditLink
-      },
+      }],
       text: {
         name: textCreditName,
         link: textCreditLink

--- a/backend/src/utils/apodScraper.ts
+++ b/backend/src/utils/apodScraper.ts
@@ -2,6 +2,7 @@
 import * as cheerio from "cheerio";
 import TurndownService from "turndown";
 import type Apod from "@/types/apod.ts";
+import { abbreviate } from "./dateUtils.ts";
 
 // TODO: make configurable so people can use different mirrors
 const APOD_URL = "https://apod.nasa.gov"
@@ -227,12 +228,7 @@ export class ApodScraper {
   }
 
   public async fromDay(date: Date): Promise<Apod> {
-    const yy = String(date.getFullYear() % 100).padStart(2, '0');
-    // Date returns date index, hence the "+ 1"
-    const mm = String(date.getMonth() + 1).padStart(2, '0');
-    const dd = String(date.getDate()).padStart(2, '0');
-
-    const url = `${APOD_URL}/apod/ap${yy}${mm}${dd}.html`;
+    const url = `${APOD_URL}/apod/ap${abbreviate(date)}.html`;
     return await this.getApodFromUrl(url)
   }
 }

--- a/backend/src/utils/apodScraper.ts
+++ b/backend/src/utils/apodScraper.ts
@@ -12,9 +12,8 @@ const turndownService = new TurndownService();
 interface ApodWebData {
   date: string | undefined;
   title: string | undefined;
-  creditAndCopyright: string | undefined;
-  creditLinks: string[];
-  creditText: string[];
+  // All centered HTML data below the image
+  imageFooter: string | undefined;
   description: string | undefined;
   imageLink: string | undefined;
 }
@@ -30,15 +29,28 @@ class ApodWebDataExtractor {
   }
 
   public buildApodData(): Apod {
-    const copyright = this.isCopyright();
+    const imageFooter = this.parseImageFooter();
     return {
       date: this.getDate(),
-      title: this.getTitle(),
-      credits: this.getCredits(),
-      copyright: copyright,
+      title: imageFooter.title,
+      credits: imageFooter.credits,
+      copyright: imageFooter.copyright,
       description: this.getDescription(),
-      imageLink: this.getImageLink(copyright)
+      imageLink: this.getImageLink(imageFooter.copyright)
     }
+  }
+
+  parseImageFooter() {
+    const imageFooter = this.webData.imageFooter;
+    if (!imageFooter) {
+      throw new ApodScraperError("Image Footer")
+    }
+
+    return {
+      copyright: this.isCopyright(imageFooter),
+      title: this.getTitle(imageFooter),
+      credits: this.getCredits(imageFooter)
+    };
   }
 
   getDate(): Date {
@@ -53,47 +65,72 @@ class ApodWebDataExtractor {
     return date;
   }
 
-  getTitle(): string {
-    if (!this.webData.title) {
+  getTitle(imageFooter: string): string {
+    const $ = cheerio.load(imageFooter);
+    const title = $("b").prop("innerText")?.trim();
+    if (!title) {
       throw new ApodScraperError("Title");
     }
-    const title = this.webData.title.trim();
     return title;
   }
 
-  isCopyright(): boolean {
-    if (!this.webData.creditAndCopyright) {
-      throw new ApodScraperError("Credit & Copyright");
-    }
-    const copyright = this.webData.creditAndCopyright
+  isCopyright(imageFooter: string): boolean {
+    const copyright = imageFooter
       .toUpperCase()
       .includes("COPYRIGHT");
 
     return copyright;
   }
 
-  getCredits() {
-    const data = this.webData;
-    if (!data.creditLinks || data.creditLinks.length < 2) {
-      throw new ApodScraperError("Links for credits");
+  getCredits(imageFooter: string) {
+    var imageCreditsHtml = imageFooter;
+    var textCredits = undefined;
+    if (imageFooter.includes("Text:")) {
+      const split = imageFooter.split("Text:");
+      imageCreditsHtml = split[0]!
+      const after = split[1]!;
+      const $ = cheerio.load(after);
+      const a = $("a");
+      const link = a.attr('href') ?? "";
+      const name = a.prop("innerText") ?? "";
+      textCredits = {
+        name: name,
+        link: link
+      };
     }
-    const imgCreditLink = data.creditLinks[0]!;
-    const textCreditLink = data.creditLinks[1]!;
-    if (!data.creditText || data.creditText.length < 2) {
-      throw new ApodScraperError("Links for credits");
+
+    // Remove values in parenthesis, they are not involved in crediting the
+    // person, but the organization that person is a part of.
+    const clearedHtml = imageCreditsHtml.replace(new RegExp("\\(.*\\)"), "");
+    const $ = cheerio.load(clearedHtml);
+    const a = $("a").get();
+    const imgCredits: {
+      name: string;
+      link: string | undefined
+    }[] = [];
+    if (a.length === 0) {
+      // If unlinked, all names will be in a single element
+      const name: string = $("b:get(1)").parent().last().prop("innerText")!;
+      imgCredits.push({ name: name, link: undefined });
+    } else {
+      a.forEach((e) => {
+        const name: string = (e.firstChild as any).data;
+        if (name.toUpperCase().includes("COPYRIGHT")) {
+          return;
+        }
+        const link = e.attribs["href"];
+        const credit = {
+          name: name,
+          link: link
+        };
+        imgCredits.push(credit);
+      })
     }
-    const imgCreditName = data.creditText[0]!;
-    const textCreditName = data.creditText[1]!;
+
     const credits = {
-      image: [{
-        name: imgCreditName,
-        link: imgCreditLink
-      }],
-      text: {
-        name: textCreditName,
-        link: textCreditLink
-      }
-    };
+      image: imgCredits,
+      text: textCredits
+    }
 
     return credits;
   }
@@ -150,7 +187,7 @@ export class ApodScraper {
     this.config = { ...this.config, ...config };
   }
 
-  async getApodWebDataExtractor(url: string) {
+  async getApodWebDataExtractor(url: string): Promise<ApodWebDataExtractor> {
     // Go to apod and get html
     const res = await fetch(url);
     if (!res.ok) {
@@ -164,12 +201,10 @@ export class ApodScraper {
     const data: ApodWebData = $.extract({
       date: "center > p:eq(1)",
       title: "center > b",
-      creditAndCopyright: "center > b:eq(1)",
-      creditLinks: [{
-        selector: "center > a",
-        value: "href"
-      }],
-      creditText: ["center > a"],
+      imageFooter: {
+        selector: "center:eq(1)",
+        value: "innerHTML"
+      },
       description: {
         selector: "body > p",
         value: "innerHTML"

--- a/backend/src/utils/dateUtils.ts
+++ b/backend/src/utils/dateUtils.ts
@@ -1,0 +1,8 @@
+export function abbreviate(date: Date) {
+  const yy = String(date.getFullYear() % 100).padStart(2, '0');
+  // Date returns date index, hence the "+ 1"
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+
+  return yy + mm + dd;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,13 +16,17 @@
         "@types/node": "^16.18.126",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "buffer": "^6.0.3",
         "dompurify": "^3.3.1",
+        "gray-matter": "^4.0.3",
         "marked": "^17.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "webpack": "^5.105.2",
+        "webpack-cli": "^6.0.1"
       },
       "devDependencies": {
         "@craco/craco": "^7.1.0"
@@ -2438,6 +2442,15 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -4312,6 +4325,50 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5193,6 +5250,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -5389,6 +5466,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5679,7 +5780,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4",
@@ -7005,6 +7105,18 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/envinfo": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
+      "license": "MIT",
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -7999,6 +8111,18 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8060,6 +8184,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -8259,7 +8392,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
@@ -8802,6 +8934,21 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "license": "MIT"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -9236,6 +9383,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9352,6 +9519,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -9523,6 +9699,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9685,7 +9870,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -9900,7 +10084,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14084,6 +14267,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -14689,6 +14884,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -14910,7 +15118,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.2"
@@ -15416,6 +15623,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-comments": {
@@ -16742,6 +16958,71 @@
         }
       }
     },
+    "node_modules/webpack-cli": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.6.1",
+        "@webpack-cli/configtest": "^3.0.1",
+        "@webpack-cli/info": "^3.0.1",
+        "@webpack-cli/serve": "^3.0.1",
+        "colorette": "^2.0.14",
+        "commander": "^12.1.0",
+        "cross-spawn": "^7.0.3",
+        "envinfo": "^7.14.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
+        "webpack-merge": "^6.0.1"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webpack-cli/node_modules/webpack-merge": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/webpack-dev-middleware": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
@@ -17104,7 +17385,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,17 @@
     "@types/node": "^16.18.126",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "buffer": "^6.0.3",
     "dompurify": "^3.3.1",
+    "gray-matter": "^4.0.3",
     "marked": "^17.0.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "webpack": "^5.105.2",
+    "webpack-cli": "^6.0.1"
   },
   "scripts": {
     "start": "craco start",

--- a/frontend/src/components/ApodContainer.tsx
+++ b/frontend/src/components/ApodContainer.tsx
@@ -44,13 +44,18 @@ function ApodDisplay({ apod }: { apod: Apod }) {
       <h1>{apod.title}</h1>
       <img src={`${APOD_URL}/${apod.imageLink}`} alt={apod.title} />
       <p>
-        Image Credit: <a href={imageCredits.link}>{imageCredits.name}</a>
+        Image Credit:
+        <ul>
+          {imageCredits.map((e) =>
+            <li key={`imgCredit-${e.name}`}><a href={e.link}>{e.name}</a></li>
+          )}
+        </ul>
       </p>
       {/* We can trust this HTML because we sanitized it */}
       <p dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(apod.description) as string) }} />
-      <p>
+      {textCredits && (<p>
         Text Credit: <a href={textCredits.link}>{textCredits.name}</a>
-      </p>
+      </p>)}
     </>
   )
 }

--- a/frontend/src/components/ApodContainer.tsx
+++ b/frontend/src/components/ApodContainer.tsx
@@ -1,4 +1,5 @@
 import { serverUrl } from "@/utils/tmpConsts";
+import mdToApod from "@/utils/mdToApod";
 import type Apod from "@backend-types/apod"
 import { useEffect, useState } from "react";
 import DOMPurify from "dompurify";
@@ -23,7 +24,7 @@ export default function ApodContainer({ date }: { date: Date }) {
       },
       body: today ? undefined : JSON.stringify({ date: date })
     })
-      .then(async r => await r.json())
+      .then(async r => mdToApod(await r.text()))
       .then(setDisplayState);
   }, [date])
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,7 +3,9 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { Buffer } from 'buffer';
 
+window.Buffer = Buffer;
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );

--- a/frontend/src/utils/mdToApod.ts
+++ b/frontend/src/utils/mdToApod.ts
@@ -1,0 +1,16 @@
+// Converts markdown and frontmatter to a json object
+import type Apod from "@backend-types/apod";
+import matter from "gray-matter";
+
+export default function mdToApod(md: string): Apod {
+  const mat = matter(md);
+  const apod: Apod = {
+    date: mat.data.date,
+    title: mat.data.title,
+    credits: mat.data.credits,
+    copyright: mat.data.copyright,
+    description: mat.content,
+    imageLink: mat.data.imageLink
+  };
+  return apod;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,6 +6,10 @@
       "dom.iterable",
       "esnext"
     ],
+    "types": [
+      "node",
+      "buffer"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "apsis",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# Summary

Apods are now stored and sent in a markdown format with YAML frontmatter, similar to [my portfolio website](https://github.com/jayhwkns/portfolio-redux). When web data is scraped, it is then stored in the cache directory specified in the backend's `main.ts`. You'll notice that the apods load much quicker when you've visited them previously. There is no functionality for cache expiration, but the apods should be mostly immutable, so it can function as a database over time.

Improvements were also made to improve web-scraper accuracy.